### PR TITLE
Use guids by default in exported JSON. Closes #8

### DIFF
--- a/src/common/JSONImporter.js
+++ b/src/common/JSONImporter.js
@@ -251,8 +251,13 @@ define([
             }
             const idString = state.id;
             const fco = await this.core.loadByPath(this.rootNode, '/1');
-            const node = this.core.createNode({base: base || fco, parent});
             const selector = new NodeSelector(idString);
+            const params = selector.prepareCreateParams({
+                    base: base || fco,
+                    parent,
+                    relid: state.path?.split('/').pop()
+                });
+            const node = this.core.createNode(params);
             await selector.prepare(this.core, this.rootNode, node);
             return node;
         }
@@ -278,7 +283,7 @@ define([
         }
 
         async import(parent, state) {
-            const node = await this.createNode(parent);
+            const node = await this.createNode(parent, state);
             await this.apply(node, state);
             return node;
         }
@@ -598,6 +603,17 @@ define([
                 this.tag = '@guid';
                 this.value = idString;
             }
+        }
+
+        prepareCreateParams(params) {
+            if (this.tag === '@guid') {
+                params.guid = this.value;
+            }
+
+            if (this.tag === '@path') {
+                params.relid = this.value.split('/').pop();
+            }
+            return params;
         }
 
         async prepare(core, rootNode, node) {

--- a/test/common/JSONImporter.spec.js
+++ b/test/common/JSONImporter.spec.js
@@ -885,6 +885,23 @@ describe('JSONImporter', function () {
             );
         });
 
+        it.only('should set guid when creating @guid nodes', async function() {
+            const fco = await core.loadByPath(root, '/1');
+            const node = core.createNode({base: fco, parent: root});
+            core.setAttribute(node, 'name', 'MyNode!');
+            const guid = '0d2e0ef3-5b8f-9bc4-45a0-8abab4433565';
+            const container = {
+                id: `@guid:${guid}`,
+                attributes: {name: 'newguidtest'},
+            };
+            const containerNode = await importer.import(root, container);
+            assert.equal(
+                core.getGuid(containerNode),
+                guid,
+                'Did not set guid on creation'
+            );
+        });
+
         describe('prepare', function() {
             it('should add @meta node to META', async function() {
                 const selector = new Importer.NodeSelector('@meta:TestMeta');

--- a/test/common/JSONImporter.spec.js
+++ b/test/common/JSONImporter.spec.js
@@ -902,6 +902,40 @@ describe('JSONImporter', function () {
             );
         });
 
+        it('should set path when creating @path nodes', async function() {
+            const fco = await core.loadByPath(root, '/1');
+            const node = core.createNode({base: fco, parent: root});
+            core.setAttribute(node, 'name', 'MyNode!');
+            const path = 'testPath';
+            const container = {
+                id: `@path:${path}`,
+                attributes: {name: 'newpathtest'},
+            };
+            const containerNode = await importer.import(root, container);
+            assert.equal(
+                core.getPath(containerNode).split('/').pop(),
+                path,
+                'Did not set path on creation'
+            );
+        });
+
+        it('should set path when "path" set', async function() {
+            const fco = await core.loadByPath(root, '/1');
+            const node = core.createNode({base: fco, parent: root});
+            core.setAttribute(node, 'name', 'MyNode!');
+            const path = 'testPath';
+            const container = {
+                path,
+                attributes: {name: 'newpathtest2'},
+            };
+            const containerNode = await importer.import(root, container);
+            assert.equal(
+                core.getPath(containerNode).split('/').pop(),
+                path,
+                'Did not set path on creation'
+            );
+        });
+
         describe('prepare', function() {
             it('should add @meta node to META', async function() {
                 const selector = new Importer.NodeSelector('@meta:TestMeta');

--- a/test/common/JSONImporter.spec.js
+++ b/test/common/JSONImporter.spec.js
@@ -885,7 +885,7 @@ describe('JSONImporter', function () {
             );
         });
 
-        it.only('should set guid when creating @guid nodes', async function() {
+        it('should set guid when creating @guid nodes', async function() {
             const fco = await core.loadByPath(root, '/1');
             const node = core.createNode({base: fco, parent: root});
             core.setAttribute(node, 'name', 'MyNode!');


### PR DESCRIPTION
The current approach can fail if the nodes move (since the path can then be invalidated). It is safer to simply use GUIDs everywhere when programmatically generating the code (more likely to be what the user wants). Of course, the other ID tags should be fine, too.