### PR TITLE
Add support for "alias" field. Closes #17

### DIFF
--- a/src/common/JSONImporter.js
+++ b/src/common/JSONImporter.js
@@ -181,6 +181,10 @@ define([
                 const parentId = this.core.getPath(parent);
                 const selector = new NodeSelector(state.id);
                 resolvedSelectors.record(parentId, selector, node);
+                if (state.alias) {
+                    const selector = new NodeSelector('@id:' + state.alias);
+                    resolvedSelectors.record(parentId, selector, node);
+                }
             }
         }
 


### PR DESCRIPTION
This PR adds support for an optional `alias` field which assigns an `@id` field implicitly so the node can be easily referenced from other nodes regardless of the actual value of `id` (allowing it to be set to relative identity resolvers).