### PR TITLE
Add support for mixins. Closes #15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "webgme-json-importer",
-      "version": "1.0.0",
+      "version": "1.2.0",
       "devDependencies": {
         "chai": "^4.3.4",
         "mocha": "^5.2.0",
@@ -14035,6 +14035,7 @@
     },
     "webgme-rust-components": {
       "version": "git+ssh://git@github.com/webgme/webgme-rust-components.git#ad446234b6c02fd722e7e454015857ee523fb172",
+      "integrity": "sha512-jS1rMUMLb7hXMhBheFxiTA+yLw068o3cheiFIH0vszWN8xGIjGXZn8YrzOmK2hkAu3HLF4lT7nuTYJ+uSZUtpA==",
       "dev": true,
       "from": "webgme-rust-components@github:webgme/webgme-rust-components"
     },

--- a/src/common/JSONImporter.js
+++ b/src/common/JSONImporter.js
@@ -328,18 +328,16 @@ define([
             const [, index] = change.key;
             const oldMixinPath = this.core.getMixinPaths(node)[index];
             if (oldMixinPath) {
-                console.log('deleting old mixin', oldMixinPath);
                 this.core.delMixin(node, oldMixinPath);
             }
 
             const mixinId = change.value;
             const mixinPath = await this.getNodeId(node, mixinId, resolvedSelectors);
-            if (this.core.canSetAsMixin(node, mixinPath)) {
-                console.log('adding mixin', mixinPath);
+            const canSet = this.core.canSetAsMixin(node, mixinPath);
+            if (canSet.isOk) {
                 this.core.addMixin(node, mixinPath);
-                console.log('mixin paths:', this.core.getMixinPaths(node));
             } else {
-                throw new Error(`Cannot set ${mixinId} as mixin for ${this.core.getPath(node)}`);
+                throw new Error(`Cannot set ${mixinId} as mixin for ${this.core.getPath(node)}: ${canSet.reason}`);
             }
     };
 
@@ -464,10 +462,8 @@ define([
     };
 
     Importer.prototype._delete.mixins = async function(node, change, resolvedSelectors) {
-            // TODO: look up the mixin at the given index. Is getMixinPaths stable?
             const [, index] = change.key;
             const mixinPath = this.core.getMixinPaths(node)[index];
-            console.log('deleting mixin', mixinPath);
             this.core.delMixin(node, mixinPath);
     };
 

--- a/src/common/README.md
+++ b/src/common/README.md
@@ -18,6 +18,7 @@ An example JSON is as follows:
         name: idOrPath,
         base: idOrPath,
     },
+    mixins: [idOrPath, ...],
     pointer_meta: {
         name: {
             idOrPath: {min=-1, max=1},  // max=-1 if it defines a set

--- a/test/common/JSONImporter.spec.js
+++ b/test/common/JSONImporter.spec.js
@@ -461,37 +461,52 @@ describe('JSONImporter', function () {
         });
 
         describe('mixins', function() {
+            let node4;
+
+            beforeEach(() => {
+                const base = node;
+                const parent = root;
+                node4 = core.createNode({base, parent});
+                core.setAttribute(node4, 'name', 'Node4');
+                core.addMember(root, 'MetaAspectSet', node4);
+
+              });
+
             it('should add mixin', async function() {
-                const nodeId = core.getPath(node);
+                const nodeId = core.getPath(node4);
                 original2.mixins.push(nodeId);
                 await importer.apply(node2, original2);
-                const mixins = Object.keys(core.getMixinNodes(node2));
+                const mixins = core.getMixinPaths(node2);
                 assert(mixins.includes(nodeId));
                 assert.equal(mixins.length, 1);
             });
 
             it('should remove mixin', async function() {
-                const nodeId = core.getPath(node);
+                const nodeId = core.getPath(node4);
                 core.addMixin(node2, nodeId);
                 await importer.apply(node2, original2);
-                const mixins = Object.keys(core.getMixinNodes(node2));
+                const mixins = core.getMixinPaths(node2);
                 assert.equal(mixins.length, 0);
             });
 
-            it.only('should change mixin', async function() {
-                const nodeId = core.getPath(node);
+            it('should change mixin', async function() {
+                const node5 = core.createNode({base: node, parent: root});
+                core.setAttribute(node5, 'name', 'Node5');
+                core.addMember(root, 'MetaAspectSet', node5);
+
+                const nodeId = core.getPath(node4);
                 core.addMixin(node2, nodeId);
-                original2.mixins.push(core.getPath(node3));
+                original2.mixins.push(core.getPath(node5));
                 await importer.apply(node2, original2);
-                const mixins = Object.keys(core.getMixinNodes(node2));
+                const mixins = core.getMixinPaths(node2);
                 assert.deepEqual(mixins, original2.mixins);
             });
 
             it('should add mixin using ID', async function() {
-                const nodeId = core.getPath(node);
-                original2.mixins.push(nodeId);
+                original2.mixins.push('@meta:Node4');
                 await importer.apply(node2, original2);
-                const mixins = Object.keys(core.getMixinNodes(node2));
+                const mixins = core.getMixinPaths(node2);
+                const nodeId = core.getPath(node4);
                 assert(mixins.includes(nodeId));
                 assert.equal(mixins.length, 1);
             });

--- a/test/common/JSONImporter.spec.js
+++ b/test/common/JSONImporter.spec.js
@@ -510,6 +510,14 @@ describe('JSONImporter', function () {
                 assert(mixins.includes(nodeId));
                 assert.equal(mixins.length, 1);
             });
+
+            it('should throw error on invalid mixin', async function() {
+                original2.mixins.push('@meta:FCO');
+                await assert.rejects(
+                    () => importer.apply(node2, original2),
+                    /Cannot set .* as mixin/
+                );
+            });
         });
 
         describe('sets', function() {

--- a/test/common/JSONImporter.spec.js
+++ b/test/common/JSONImporter.spec.js
@@ -460,6 +460,43 @@ describe('JSONImporter', function () {
             });
         });
 
+        describe('mixins', function() {
+            it('should add mixin', async function() {
+                const nodeId = core.getPath(node);
+                original2.mixins.push(nodeId);
+                await importer.apply(node2, original2);
+                const mixins = Object.keys(core.getMixinNodes(node2));
+                assert(mixins.includes(nodeId));
+                assert.equal(mixins.length, 1);
+            });
+
+            it('should remove mixin', async function() {
+                const nodeId = core.getPath(node);
+                core.addMixin(node2, nodeId);
+                await importer.apply(node2, original2);
+                const mixins = Object.keys(core.getMixinNodes(node2));
+                assert.equal(mixins.length, 0);
+            });
+
+            it.only('should change mixin', async function() {
+                const nodeId = core.getPath(node);
+                core.addMixin(node2, nodeId);
+                original2.mixins.push(core.getPath(node3));
+                await importer.apply(node2, original2);
+                const mixins = Object.keys(core.getMixinNodes(node2));
+                assert.deepEqual(mixins, original2.mixins);
+            });
+
+            it('should add mixin using ID', async function() {
+                const nodeId = core.getPath(node);
+                original2.mixins.push(nodeId);
+                await importer.apply(node2, original2);
+                const mixins = Object.keys(core.getMixinNodes(node2));
+                assert(mixins.includes(nodeId));
+                assert.equal(mixins.length, 1);
+            });
+        });
+
         describe('sets', function() {
             const setName = 'someSet';
             let node4;


### PR DESCRIPTION
This PR adds mixins to the spec and implements it. Mixins are now supported using the `mixins` field which simply contains a list of `idOrPath`s. Invalid mixins will result in an error thrown in the `apply`/`import` function.

- WIP #15. Add initial support for mixins
- Fixed canSetAsMixin check
- Ensure error thrown for invalid mixin
